### PR TITLE
Update usage examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ npm install @streetscape.gl/monochrome
 
 ## Examples & Documentation
 
-[Styling Guide](docs/api-reference/styling-guide.md)
-
-[Storybook](https://uber-web.github.io/monochrome/)
+- [Styling Guide](docs/api-reference/styling-guide.md)
+- [Storybook](https://uber-web.github.io/monochrome/)
 
 ## Development
 

--- a/src/drag-drop-list/README.md
+++ b/src/drag-drop-list/README.md
@@ -4,41 +4,49 @@ A stateless component that renders a list of items that can be reorganized using
 
 ## Usage
 
-    import {DragDropList} from '@streetscape.gl/monochrome';
+```js
+import {DragDropList} from '@streetscape.gl/monochrome';
 
-    <DragDropList items={[
+const View = () => {
+  return (
+    <DragDropList
+      items={[
         {key: '0', content: 'Item 0'},
         {key: '1', content: 'Item 1'},
         {key: '2', content: 'Item 2'}
-      ]} onListChange={...} />
+      ]}
+      onListChange={() => {}}
+    />
+  );
+};
+```
 
 ## API Reference
 
 ### Props
 
-* `items` **(array)** - list of items to render. Each item should have the following fields:
-  + `key` **(string)** - unique identifier
-  + `content` **(node)** - renderable content of the item
-  + `[title]` **(string)** - header of the item. If specified, only the header is draggable.
-  + `[className]` **(string)** - additional class name
-* `canRemoveItem` **(boolean)** - whether an item can be removed if it's dragged too far.
-Default `false`.
-* `onListChange` **(function)** - callback when the user drops an item.
-Parameters:
-  + `event.items` **(array)** - rearranged items list
-  + `event.removedItems` **(array)** - removed items
-  + `event.targetRect` **(object)** - the bounding box of where the item is dropped
-* `style` **(object, optional)** - custom CSS styles. See "styling" section below.
-
+- `items` **(array)** - list of items to render. Each item should have the following fields:
+  - `key` **(string)** - unique identifier
+  - `content` **(node)** - renderable content of the item
+  - `[title]` **(string)** - header of the item. If specified, only the header is draggable.
+  - `[className]` **(string)** - additional class name
+- `canRemoveItem` **(boolean)** - whether an item can be removed if it's dragged too far.
+  Default `false`.
+- `onListChange` **(function)** - callback when the user drops an item.
+  Parameters:
+  - `event.items` **(array)** - rearranged items list
+  - `event.removedItems` **(array)** - removed items
+  - `event.targetRect` **(object)** - the bounding box of where the item is dropped
+- `style` **(object, optional)** - custom CSS styles. See "styling" section below.
 
 ### Styling
 
 The `style` prop expects an object that may contain the following keys:
 
-* `wrapper` - wrapper element around the whole control.
-* `item` - container of one list item.
-* `title` - the title element of each list item.
-* `placeholder` - the placeholder element when reordering.
+- `wrapper` - wrapper element around the whole control.
+- `item` - container of one list item.
+- `title` - the title element of each list item.
+- `placeholder` - the placeholder element when reordering.
 
 The values define the styling overrides for the respective child components. Unless noted otherwise, each value is an object, or a callback function.
 
@@ -58,16 +66,16 @@ const sliderStyle = {
 
 The `wrapper` callback function will receive the following arguments:
 
-* `props` **(object)**
+- `props` **(object)**
   - `theme` **(object)** - the current theme
   - `isDragging` **(boolean)** - if the user is dragging an item
   - `isRemoving` **(boolean)** - if the user is removing an item
 
 Other style callback functions will receive the following arguments:
 
-* `props` **(object)**
+- `props` **(object)**
   - `theme` **(object)** - the current theme
   - `isHovered` **(boolean)** - if the pointer is hovering over the header (if `item.title` is specified) or the item
   - `isDragging` **(boolean)** - if the item is being dragged
   - `isActive` **(boolean)** - if the item is being dragged or animating after being dropped
-  - `isRemoved`  **(boolean)** - if the item is being removed
+  - `isRemoved` **(boolean)** - if the item is being removed

--- a/src/float-panel/README.md
+++ b/src/float-panel/README.md
@@ -4,45 +4,48 @@ A stateless component that renders a floating panel.
 
 **Features**
 
-* Move
-* Resize
-* Minimize
-* Constrain inside bounds
+- Move
+- Resize
+- Minimize
+- Constrain inside bounds
 
 ## Usage
 
-    import {FloatPanel} from '@streetscape.gl/monochrome';
+```js
+import {FloatPanel} from '@streetscape.gl/monochrome';
 
-    <FloatPanel title="My Window" x={0} y={10} width={200} height={200} />
+const View = () => {
+  return <FloatPanel title="My Window" x={0} y={10} width={200} height={200} />;
+};
+```
 
 ## API Reference
 
 ## Props
 
-* `title` **(string|Element)** - content to display in the title bar. If empty, the title bar will be hidden.
-* `x` **(number)** - position from the left in pixels
-* `y` **(number)** - position from the top in pixels
-* `width` **(number)** - width of the panel
-* `height` **(number)** - height of the panel
-* `className` **(string, optional)** - additional class name for the container
-* `parentWidth` **(number, optional)** - width of the parent window
-* `parentHeight` **(number, optional)** - height of the parent window. If parent window size is specified, the panel cannot be moved outside of its bounds.
-* `minimized` **(boolean, optional)** - whether the panel is minimized (show only title bar)
-* `movable` **(boolean, optional)** - whether the panel can be moved, default true
-* `resizable` **(boolean, optional)** - whether the panel can be resized, default false
-* `minimizable` **(boolean, optional)** - whether the panel can be minimized, default true
-* `onUpdate` **(function, optional)** - callback when user move/resize/minimize the panel
-* `style` **(object, optional)** - cursom CSS overrides. See "styling" section below.
-
+- `title` **(string|Element)** - content to display in the title bar. If empty, the title bar will be hidden.
+- `x` **(number)** - position from the left in pixels
+- `y` **(number)** - position from the top in pixels
+- `width` **(number)** - width of the panel
+- `height` **(number)** - height of the panel
+- `className` **(string, optional)** - additional class name for the container
+- `parentWidth` **(number, optional)** - width of the parent window
+- `parentHeight` **(number, optional)** - height of the parent window. If parent window size is specified, the panel cannot be moved outside of its bounds.
+- `minimized` **(boolean, optional)** - whether the panel is minimized (show only title bar)
+- `movable` **(boolean, optional)** - whether the panel can be moved, default true
+- `resizable` **(boolean, optional)** - whether the panel can be resized, default false
+- `minimizable` **(boolean, optional)** - whether the panel can be minimized, default true
+- `onUpdate` **(function, optional)** - callback when user move/resize/minimize the panel
+- `style` **(object, optional)** - cursom CSS overrides. See "styling" section below.
 
 ### Styling
 
 The `style` prop expects an object that may contain the following keys:
 
-* `wrapper` - wrapper around the whole control
-* `title` - title bar of the float panel
-* `content` - content of the float panel
-* `resizer` - hit area of the resize button
+- `wrapper` - wrapper around the whole control
+- `title` - title bar of the float panel
+- `content` - content of the float panel
+- `resizer` - hit area of the resize button
 
 The values define the styling overrides for the respective child components. Unless noted otherwise, each value is an object, or a callback function.
 
@@ -60,7 +63,7 @@ const floatPanelStyle = {
 
 A custom style callback function will receive the following arguments:
 
-* `props` **(object)**
+- `props` **(object)**
   - `theme` **(object)** - the current theme
   - `isMoving` **(boolean)** - if the float panel is being moved
   - `isResizing` **(boolean)** - if the float panel is being resized

--- a/src/form/README.md
+++ b/src/form/README.md
@@ -4,24 +4,34 @@ This component sets up a list of input controls using JSON descriptors.
 
 ## Usage
 
-    import {Form} from '@streetscape.gl/monochrome';
+```js
+import {Form} from '@streetscape.gl/monochrome';
 
+const SETTINGS = {
+  userHeader: {type: 'header', title: 'User Settings'},
+  userType: {
+    type: 'radio',
+    title: 'Type',
+    values: {
+      visitor: 'Visitor',
+      author: 'Author',
+      admin: 'Admin'
+    }
+  },
+  isPublic: {type: 'checkbox', title: 'Profile is public'},
+  userName: {type: 'text', title: 'Display Name'}
+};
+
+const View = () => {
+  return (
     <Form
       data={SETTINGS}
       values={this.state.values}
-      onChange={values => this.setState({values: {...this.state.values, ...values}}) />
-
-    const SETTINGS = {
-      userHeader: {type: 'header', title: 'User Settings'},
-      userType: {type: 'radio', title: 'Type', values: {
-        visitor: 'Visitor',
-        author: 'Author',
-        admin: 'Admin'
-      }},
-      isPublic: {type: 'checkbox', title: 'Profile is public'},
-      userName: {type: 'text', title: 'Display Name'},
-      ...
-    };
+      onChange={values => this.setState({values: {...this.state.values, ...values}})}
+    />
+  );
+};
+```
 
 ## API Reference
 
@@ -32,14 +42,15 @@ This component sets up a list of input controls using JSON descriptors.
 A map from key to config object for each input. Keys must be unique.
 
 Config object fields:
-* `type`: type of the control, see next section
-* `title`: label of the control, usually displayed on top. Can be set to empty. Styling may vary based on the control type.
-* `tooltip`: show hover tooltip that provides further information about this setting.
-* `badge`: show an additional badge next to the label.
-* `visible`: if this control is visible. Can be a boolean, or function that takes the current values object and returns a boolean.
-* `enabled`: if this control is enabled. Can be a boolean, or function that takes the current values object and returns a boolean.
-* `children`: a nested settings object. The nested controls will be indented to align with the parent label.
-* `style`: custom CSS overrides. See `Styling` section below.
+
+- `type`: type of the control, see next section
+- `title`: label of the control, usually displayed on top. Can be set to empty. Styling may vary based on the control type.
+- `tooltip`: show hover tooltip that provides further information about this setting.
+- `badge`: show an additional badge next to the label.
+- `visible`: if this control is visible. Can be a boolean, or function that takes the current values object and returns a boolean.
+- `enabled`: if this control is enabled. Can be a boolean, or function that takes the current values object and returns a boolean.
+- `children`: a nested settings object. The nested controls will be indented to align with the parent label.
+- `style`: custom CSS overrides. See `Styling` section below.
 
 #### `values` (Object, required)
 
@@ -49,7 +60,6 @@ A flattened map from key to current value for each setting.
 
 Callback when the value of an input is changed.
 
-
 ### Supported Control Types
 
 Each control is a key value in the settings definitions object.
@@ -57,67 +67,67 @@ The name of the key will be used to update the separate settings value object.
 
 #### Title
 
-* `type` - `title`
+- `type` - `title`
 
 Adds the title for a bigger section of setting controls.
 
 #### Header
 
-* `type` - `header`
+- `type` - `header`
 
 Adds the title for a section of setting controls.
 
 #### Separator
 
-* `type` - `separator`
+- `type` - `separator`
 
 Adds a horizontal separator
 
 #### Text
 
-* `type` - `text`
-* `showClearButton` **(boolean)** - whether should show a clear text button
+- `type` - `text`
+- `showClearButton` **(boolean)** - whether should show a clear text button
 
 Adds a text box.
 See [TextBox](./textbox.md).
 
 #### Range
 
-* `type` - `range`
-* `min` **(number)** - minimum value
-* `max` **(number)** - maximum value
-* `step` **(number)** - step value
+- `type` - `range`
+- `min` **(number)** - minimum value
+- `max` **(number)** - maximum value
+- `step` **(number)** - step value
 
 Adds a slider.
 See [Slider](./slider.md).
 
 #### Radio
 
-* `type` - `radio`
-* `data` **(object)** - A value to display name mapping object
+- `type` - `radio`
+- `data` **(object)** - A value to display name mapping object
 
 Adds a radio box.
 See [RadioBox](./radiobox.md).
 
 #### Select
 
-* `type` - `select`
-* `data` **(object)** - A value to display name mapping object
+- `type` - `select`
+- `data` **(object)** - A value to display name mapping object
 
 Adds a dropdown.
 See [Dropdown](./dropdown.md).
 
 #### Checkbox
 
-* `type` - `checkbox`
+- `type` - `checkbox`
 
 Adds a 3-state checkbox. `value` is one of `on`, `indeterminate`, or `off`.
 See [Checkbox](./checkbox.md).
 
 #### Custom
 
-* `type` - `custom`
-* `render` **(function)** - A function that returns React node. Recieves self and `{isEnabled}` as arguments.
+- `type` - `custom`
+- `render` **(function)** - A function that returns React node. Recieves self and `{isEnabled}` as arguments.
 
 This can be used to a add a custom control to the form.
 
@@ -125,13 +135,13 @@ This can be used to a add a custom control to the form.
 
 The `style` prop expects an object that may contain the following keys:
 
-* `wrapper` - wrapper element around the whole form.
-* `expander` - the expand/collapse button for input groups.
-* `iconExpanded` **(element)**  - the icon for expanded groups.
-* `iconCollapsed` **(element)**  - the icon for collapsed groups.
-* `item` - the container of each input item.
-* `[type]` - **(object)** style to be passed to each type of input component.
-* `label` - **(object)** the labels. The value will be passed to the [Label](docs/api-reference/label.md) component.
+- `wrapper` - wrapper element around the whole form.
+- `expander` - the expand/collapse button for input groups.
+- `iconExpanded` **(element)** - the icon for expanded groups.
+- `iconCollapsed` **(element)** - the icon for collapsed groups.
+- `item` - the container of each input item.
+- `[type]` - **(object)** style to be passed to each type of input component.
+- `label` - **(object)** the labels. The value will be passed to the [Label](docs/api-reference/label.md) component.
 
 The values define the styling overrides for the respective child components. Unless noted otherwise, each value is an object, or a callback function.
 
@@ -155,18 +165,18 @@ const checkboxStyle = {
 
 The `wrapper` callback function will receive the following arguments:
 
-* `props` **(object)**
+- `props` **(object)**
   - `theme` **(object)** - the current theme
 
 The `expander` callback function will receive the following arguments:
 
-* `props` **(object)**
+- `props` **(object)**
   - `theme` **(object)** - the current theme
   - `isExpanded` **(boolean)** - if the group is expanded
 
 The `item` callback function will receive the following arguments:
 
-* `props` **(object)**
+- `props` **(object)**
   - `theme` **(object)** - the current theme
   - `level` **(number)** - the nested level of the item. Root level settings have `level: 0`.
   - `isEnabled` **(boolean)** - whether the item is enabled

--- a/src/metric-card/README.md
+++ b/src/metric-card/README.md
@@ -4,26 +4,31 @@ Components that render a plot of multiple data series.
 
 **Features**
 
-* Multiple series
-* Legends and toggles
-* Fully stylable
-* Hover tooltip
+- Multiple series
+- Legends and toggles
+- Fully stylable
+- Hover tooltip
 
 ## Usage
 
-    import {MetricCard, MetricChart, RichMetricChart} from '@streetscape.gl/monochrome';
+```js
+import {MetricCard, MetricChart, RichMetricChart} from '@streetscape.gl/monochrome';
 
-    <MetricCard
-      title="Speed"
-      description="This chart shows measured speed" >
+const View = () => {
+  return (
+    <MetricCard title="Speed" description="This chart shows measured speed">
       <MetricChart
         data={{
-            car: [{x: 0, y: 0}, {x: 1, y: 0.5}, {x: 2, y: 1}]
-            train: [{x: 0, y: 0}, {x: 1, y: 0.2}, {x: 2, y: 2}]
+          car: [{x: 0, y: 0}, {x: 1, y: 0.5}, {x: 2, y: 1}],
+          train: [{x: 0, y: 0}, {x: 1, y: 0.2}, {x: 2, y: 2}]
         }}
         unit="m/s"
-        highlightX={0} />
+        highlightX={0}
+      />
     </MetricCard>
+  );
+};
+```
 
 ## API Reference
 
@@ -33,33 +38,31 @@ Components that render a plot of multiple data series.
 
 ### Props
 
-* `className` **(string, optional)** - additional class name for the container
-* `style` **(object, optional)** - custom CSS styles. See "styling" section below.
-* `title` **(string|Element)** - title of the chart. If empty, the title bar will be hidden.
-* `description` **(string|Element)** - description of the chart. It is shown when the title is hovered.
-* `isLoading` **(bool)** - show a loading spinner
-* `error` **(string)** - show a message if loading the chart encounters an error.
-
+- `className` **(string, optional)** - additional class name for the container
+- `style` **(object, optional)** - custom CSS styles. See "styling" section below.
+- `title` **(string|Element)** - title of the chart. If empty, the title bar will be hidden.
+- `description` **(string|Element)** - description of the chart. It is shown when the title is hovered.
+- `isLoading` **(bool)** - show a loading spinner
+- `error` **(string)** - show a message if loading the chart encounters an error.
 
 ### Styling
 
 The `style` prop expects an object that may contain the following keys:
 
-* `wrapper` - the container of the card.
-* `title` - the title of the card.
-* `spinner` - the spinner that is shown when the card is loading.
-* `error` - the error message.
-* `tooltip` - the title tooltip. This value will be passed to the [Tooltip](/docs/api-reference/popover.md) component.
+- `wrapper` - the container of the card.
+- `title` - the title of the card.
+- `spinner` - the spinner that is shown when the card is loading.
+- `error` - the error message.
+- `tooltip` - the title tooltip. This value will be passed to the [Tooltip](/docs/api-reference/popover.md) component.
 
 The values define the styling overrides for the respective child components. Unless noted otherwise, each value is an object, or a callback function.
 
 A custom style callback function will receive the following arguments:
 
-* `props` **(object)**
+- `props` **(object)**
   - `theme` **(object)** - the current theme
   - `hasError` **(boolean)**
   - `isLoading` **(boolean)**
-
 
 ## MetricChart
 
@@ -67,77 +70,75 @@ A custom style callback function will receive the following arguments:
 
 ### Data Props
 
-* `data` **(object)** - data to render, as a map from series name to an array of points.
-* `highlightX` **(number)** - x position of the crosshair when the chart is not hovered.
-* `unit` **(string, optional)** - unit of the y axis.
-* `getX` **(function, optional)** - accessor of the `x` value from each data point. Default `d => d.x`.
-* `getY` **(function, optional)** - accessor of the `y` value from each data point. Default `d => d.y`.
-* `getY0` **(function, optional)** - accessor of the `y0` value from each data point. Default `d => null`. If `y0` is not null, the series is rendered as an area filled from `y0` (bottom) to `y` (top).
+- `data` **(object)** - data to render, as a map from series name to an array of points.
+- `highlightX` **(number)** - x position of the crosshair when the chart is not hovered.
+- `unit` **(string, optional)** - unit of the y axis.
+- `getX` **(function, optional)** - accessor of the `x` value from each data point. Default `d => d.x`.
+- `getY` **(function, optional)** - accessor of the `y` value from each data point. Default `d => d.y`.
+- `getY0` **(function, optional)** - accessor of the `y0` value from each data point. Default `d => null`. If `y0` is not null, the series is rendered as an area filled from `y0` (bottom) to `y` (top).
 
 ### Styling Props
 
-* `width` **(number|string, optional)** - width of the chart. Default `100%`.
-* `height` **(number|string, optional)** - height of the chart. Default `300`.
-* `style` **(object, optional)** - custom CSS styles. See "styling" section below.
-* `xDomain` **([number, number], optional)** - [min, max] of the x axis.
-* `yDomain` **([number, number], optional)** - [min, max] of the y axis.
-* `xTicks` **(number, optional)** - number of ticks to show on the x axis. Default `4`.
-* `yTicks` **(number, optional)** - number of ticks to show on the y axis. Default `4`.
-* `horizontalGridLines` **(number, optional)** - number of horizontal grid lines. Default `4`.
-* `verticalGridLines` **(number, optional)** - number of vertical grid lines. Default `4`.
-* `formatXTick` **(function, optional)** - format the label along the x axis.
-* `formatYTick` **(function, optional)** - format the label along the y axis.
-* `formatTitle` **(function, optional)** - format a series name for display in the tooltip.
-* `formatValue` **(function, optional)** - format a data value for display in the tooltip.
-* `getColor` **(object|function|string, optional)** - the color accessor of a series. Default `#000`.
-  + Type `string`: a CSS color string.
-  + Type `object`: a map from series name to its CSS color.
-  + Type `function`: a callback that receives a series name and returns its CSS color.
+- `width` **(number|string, optional)** - width of the chart. Default `100%`.
+- `height` **(number|string, optional)** - height of the chart. Default `300`.
+- `style` **(object, optional)** - custom CSS styles. See "styling" section below.
+- `xDomain` **([number, number], optional)** - [min, max] of the x axis.
+- `yDomain` **([number, number], optional)** - [min, max] of the y axis.
+- `xTicks` **(number, optional)** - number of ticks to show on the x axis. Default `4`.
+- `yTicks` **(number, optional)** - number of ticks to show on the y axis. Default `4`.
+- `horizontalGridLines` **(number, optional)** - number of horizontal grid lines. Default `4`.
+- `verticalGridLines` **(number, optional)** - number of vertical grid lines. Default `4`.
+- `formatXTick` **(function, optional)** - format the label along the x axis.
+- `formatYTick` **(function, optional)** - format the label along the y axis.
+- `formatTitle` **(function, optional)** - format a series name for display in the tooltip.
+- `formatValue` **(function, optional)** - format a data value for display in the tooltip.
+- `getColor` **(object|function|string, optional)** - the color accessor of a series. Default `#000`.
+  - Type `string`: a CSS color string.
+  - Type `object`: a map from series name to its CSS color.
+  - Type `function`: a callback that receives a series name and returns its CSS color.
 
 ### Event Callback Props
 
-* `onClick` **(function, optional)** - Called when the chart is clicked. Parameters:
-  + `x` (number) - x value at the pointer position.
-* `onMouseEnter` **(function, optional)** - Called when the pointer enters the chart area.
-* `onMouseMove` **(function, optional)** - Called when the pointer moves inside the chart area.
-* `onMouseLeave` **(function, optional)** - Called when the pointer leaves the chart area.
-* `onSeriesMouseOver` **(function, optional)** - Called when the pointer enters a line series. Parameters:
-  + `key` (string) - name of the series.
-* `onNearestX` **(function, optional)** - Called when the pointer moves relative to a line series. Parameters:
-  + `key` (string) - name of the series.
-  + `value` (object) - datum that is closest to the pointer.
-* `onSeriesMouseOut` **(function, optional)** - Called when the pointer leaves a line series. Parameters:
-  + `key` (string) - name of the series.
-
+- `onClick` **(function, optional)** - Called when the chart is clicked. Parameters:
+  - `x` (number) - x value at the pointer position.
+- `onMouseEnter` **(function, optional)** - Called when the pointer enters the chart area.
+- `onMouseMove` **(function, optional)** - Called when the pointer moves inside the chart area.
+- `onMouseLeave` **(function, optional)** - Called when the pointer leaves the chart area.
+- `onSeriesMouseOver` **(function, optional)** - Called when the pointer enters a line series. Parameters:
+  - `key` (string) - name of the series.
+- `onNearestX` **(function, optional)** - Called when the pointer moves relative to a line series. Parameters:
+  - `key` (string) - name of the series.
+  - `value` (object) - datum that is closest to the pointer.
+- `onSeriesMouseOut` **(function, optional)** - Called when the pointer leaves a line series. Parameters:
+  - `key` (string) - name of the series.
 
 ### Styling
 
 The `style` prop expects an object that may contain the following keys:
 
-* `margin` **(object)** - margin of the plot. Default `{left: 32, top: 20, right: 20, bottom: 32}`.
-* `chart` - the chart component
-* `crosshair` - the info box shown on hover
-* `crosshairTitle` - the series names in the tooltip
-* `crosshairValue` - the value texts in the tooltip
-* `crosshairLegend` - the color legends in the tooltip
+- `margin` **(object)** - margin of the plot. Default `{left: 32, top: 20, right: 20, bottom: 32}`.
+- `chart` - the chart component
+- `crosshair` - the info box shown on hover
+- `crosshairTitle` - the series names in the tooltip
+- `crosshairValue` - the value texts in the tooltip
+- `crosshairLegend` - the color legends in the tooltip
 
 The values define the styling overrides for the respective child components. Unless noted otherwise, each value is an object, or a callback function.
 
 A custom style callback function will receive the following arguments:
 
-* `props` **(object)**
+- `props` **(object)**
   - `theme` **(object)** - the current theme
 
 The `tooltipTitle`, `tooltipValue` and `tooltipLegend` callbacks will receive the following arguments:
 
-* `props` **(object)**
+- `props` **(object)**
   - `theme` **(object)** - the current theme
   - `name` **(string)** - key of the series
   - `displayName` **(string)** - dispay name of the series
   - `color` **(string)** - color of the series
   - `isFirst` **(boolean)** - if this is the first item in the list
   - `isLast` **(boolean)** - if this is the last item in the list
-
 
 ## RichMetricChart
 
@@ -147,30 +148,29 @@ The `tooltipTitle`, `tooltipValue` and `tooltipLegend` callbacks will receive th
 
 Every prop supported by `MetricChart`, plus the following:
 
-* `topSeriesCount` **(number)** - Number of series to display by default. The data series are sorted by their peak value.
-
+- `topSeriesCount` **(number)** - Number of series to display by default. The data series are sorted by their peak value.
 
 ### Styling
 
 The `style` prop expects an object that may contain any of the stylable components of the `MetricChart`, plus the following:
 
-* `filter` - the filter container
-* `filterToggle` - the toggle to show/hide additional filters
-* `iconExpanded` **(element)**  - the icon when filters are expanded.
-* `iconCollapsed` **(element)**  - the icon when filters are collapsed.
-* `iconOn` **(element)**  - the icon for a filter that is on.
-* `iconOff` **(element)**  - the icon for a filter that is off.
-* `filterItem` - the name of a series in the filters
-* `filterLegend` - the color legend of a series in the filters
+- `filter` - the filter container
+- `filterToggle` - the toggle to show/hide additional filters
+- `iconExpanded` **(element)** - the icon when filters are expanded.
+- `iconCollapsed` **(element)** - the icon when filters are collapsed.
+- `iconOn` **(element)** - the icon for a filter that is on.
+- `iconOff` **(element)** - the icon for a filter that is off.
+- `filterItem` - the name of a series in the filters
+- `filterLegend` - the color legend of a series in the filters
 
 The `filter` callback function will receive the following arguments:
 
-* `props` **(object)**
+- `props` **(object)**
   - `theme` **(object)** - the current theme
 
 The `filterItem` and `filterLegend` callbacks will receive the following arguments:
 
-* `props` **(object)**
+- `props` **(object)**
   - `theme` **(object)** - the current theme
   - `name` **(string)** - key of the series
   - `displayName` **(string)** - dispay name of the series

--- a/src/playback-control/README.md
+++ b/src/playback-control/README.md
@@ -4,26 +4,35 @@ A stateless video playback control component.
 
 **Features**
 
-* Play / Pause
-* Seeking
-* Responsive labels
-* Markers
-
+- Play / Pause
+- Seeking
+- Responsive labels
+- Markers
 
 ## Usage
 
-    import {PlaybackControl} from '@streetscape.gl/monochrome';
-
-    <PlaybackControl currentTime={8.3} endTime={20} isPlaying={false} onPlay={...} onSeek={...} />
-
+```js
+import {PlaybackControl} from '@streetscape.gl/monochrome';
+const View = () => {
+  return (
+    <PlaybackControl
+      currentTime={8.3}
+      endTime={20}
+      isPlaying={false}
+      onPlay={() => {}}
+      onSeek={() => {}}
+    />
+  );
+};
+```
 
 ## API Reference
 
 ### Static Methods
 
-* `PlaybackControl.formatTimeCode` - 
-  + `value` **(number)** - time in seconds
-  + `format` **(string)** - format code, default `{hh}:{mm}:{ss}.{SSS}`.
+- `PlaybackControl.formatTimeCode` -
+  - `value` **(number)** - time in seconds
+  - `format` **(string)** - format code, default `{hh}:{mm}:{ss}.{SSS}`.
     - `h` - hours
     - `m` - minutes
     - `s` - seconds
@@ -31,54 +40,53 @@ A stateless video playback control component.
 
 ### Props
 
-* `width` **(string|number)** -  width of the control. Default `100%`.
-* `style` **(object, optional)** - custom CSS overrides. See "Styling" section below.
-* `compact` **(boolean, optional)** - use compact layout mode of the control. Defaults to `false`.
-* `currentTime` **(number)** -  current time in seconds
-* `startTime` **(number, optional)** -  start time in seconds, default `0`
-* `endTime` **(number)** -  end time in seconds
-* `isPlaying` **(boolean)** -  whether the video is playing
-* `step` **(number, optional)** -  scrub interval in seconds
-* `tickSpacing` **(number, optional)** -  spacing between ticks in pixels, default `100`.
-* `formatTick` **(function, optional)** -  format of ticks. Default `t => formatTimeCode(t, '{mm}:{ss}')`.
-* `formatTimestamp` **(function, optional)** -  format of the current time label. Default `t => formatTimeCode(t, '{mm}:{ss}.{S}')`.
-* `className` **(string, optional)** -  additional class name
-* `bufferRange` **(array|object, optional)** -  one or multiple time ranges of loaded buffers to mark the track. Each item should contain the following fields:
-  + `startTime` **(number)** starting timestamp of a time range
-  + `endTime` **(number)** ending timestamp of a time range
-* `markers` **(array, optional)** -  array of additional highlights to mark the timeline. Each marker should contain the following fields:
-  + `time` or `startTime`, `endTime` **(number)** a single timestamp or a time range
-  + `style` **(object, optional)** style of the marker
-  + `content` **(element, optional)** content of the marker
-* `onPlay` **(function, optional)** -  callback when user play.
-* `onPause` **(function, optional)** -  callback when user pause.
-* `onSeek` **(function, optional)** -  callback when user scrubs.
-
+- `width` **(string|number)** - width of the control. Default `100%`.
+- `style` **(object, optional)** - custom CSS overrides. See "Styling" section below.
+- `compact` **(boolean, optional)** - use compact layout mode of the control. Defaults to `false`.
+- `currentTime` **(number)** - current time in seconds
+- `startTime` **(number, optional)** - start time in seconds, default `0`
+- `endTime` **(number)** - end time in seconds
+- `isPlaying` **(boolean)** - whether the video is playing
+- `step` **(number, optional)** - scrub interval in seconds
+- `tickSpacing` **(number, optional)** - spacing between ticks in pixels, default `100`.
+- `formatTick` **(function, optional)** - format of ticks. Default `t => formatTimeCode(t, '{mm}:{ss}')`.
+- `formatTimestamp` **(function, optional)** - format of the current time label. Default `t => formatTimeCode(t, '{mm}:{ss}.{S}')`.
+- `className` **(string, optional)** - additional class name
+- `bufferRange` **(array|object, optional)** - one or multiple time ranges of loaded buffers to mark the track. Each item should contain the following fields:
+  - `startTime` **(number)** starting timestamp of a time range
+  - `endTime` **(number)** ending timestamp of a time range
+- `markers` **(array, optional)** - array of additional highlights to mark the timeline. Each marker should contain the following fields:
+  - `time` or `startTime`, `endTime` **(number)** a single timestamp or a time range
+  - `style` **(object, optional)** style of the marker
+  - `content` **(element, optional)** content of the marker
+- `onPlay` **(function, optional)** - callback when user play.
+- `onPause` **(function, optional)** - callback when user pause.
+- `onSeek` **(function, optional)** - callback when user scrubs.
 
 ### Styling
 
 The `style` prop expects an object that may contain the following keys:
 
-* `padding` **(number|object)** -  padding at the sides of the slider in pixels. If provided as object, in the shape of `{left, right}`. Default `24`.
-* `wrapper` - the top level container.
-* `ticks` - the container of the ticks.
-* `tick` - one of the ticks.
-* `tickLabel` - the label of a tick.
-* `markers` - the container of the markers.
-* `marker` - one of the markers.
-* `buffer` - one of the buffer indicators.
-* `slider` **(object)** - the slider. The value will be passed to the [Slider](docs/api-reference/slider.md) component.
-* `controls` - the container of the controls.
-* `playPauseButton` - the play/pause button.
-* `iconPlay` **(element)**  - the play icon.
-* `iconPause` **(element)**  - the pause icon.
-* `timestamp` - the timestamp.
+- `padding` **(number|object)** - padding at the sides of the slider in pixels. If provided as object, in the shape of `{left, right}`. Default `24`.
+- `wrapper` - the top level container.
+- `ticks` - the container of the ticks.
+- `tick` - one of the ticks.
+- `tickLabel` - the label of a tick.
+- `markers` - the container of the markers.
+- `marker` - one of the markers.
+- `buffer` - one of the buffer indicators.
+- `slider` **(object)** - the slider. The value will be passed to the [Slider](docs/api-reference/slider.md) component.
+- `controls` - the container of the controls.
+- `playPauseButton` - the play/pause button.
+- `iconPlay` **(element)** - the play icon.
+- `iconPause` **(element)** - the pause icon.
+- `timestamp` - the timestamp.
 
 The values define the styling overrides for the respective child components. Unless noted otherwise, each value is an object, or a callback function.
 
 A custom style callback function will receive the following arguments:
 
-* `props` **(object)**
+- `props` **(object)**
   - `theme` **(object)** - the current theme
   - `compact` **(boolean)**
   - `isPlaying` **(boolean)**

--- a/src/table/README.md
+++ b/src/table/README.md
@@ -4,12 +4,15 @@ A collection of React components that render very large tables.
 
 ## Usage
 
-    import {Table} from '@streetscape.gl/monochrome';
+```js
+import {Table} from '@streetscape.gl/monochrome';
 
-    <Table columns={columns}
-      rows={rows}
-      renderHeader={renderHeader}
-      renderCell={renderCell} />
+const View = () => {
+  return (
+    <Table columns={columns} rows={rows} renderHeader={renderHeader} renderCell={renderCell} />
+  );
+};
+```
 
 ## Table
 
@@ -25,20 +28,19 @@ import {Table} from '@streetscape.gl/monochrome';
 - `height` **(string|number)** - height of the table. Default `400`.
 - `style` **(object)** - custom CSS overrides. See "Styling" section below.
 - `columns` **(array)** - list of column definitions. Each column definition may contain the following fields:
-    + `name` **(string)** - display name of the column.
-    + `type` **(string)** - `string`, `boolean`, etc.
+  - `name` **(string)** - display name of the column.
+  - `type` **(string)** - `string`, `boolean`, etc.
 - `rows` **(array)** - list of rows to render. Each row object must contain the following fields:
-    + `data` **(array)** - value for each column, e.g. `[val1, val2, ...]`
+  - `data` **(array)** - value for each column, e.g. `[val1, val2, ...]`
 - `renderHeader` **(function, optional)** - custom renderer for each column's header. Receives one argument with the following fields:
-    + `column` **(object)** - the column definition
-    + `columnIndex` **(number)** - the column index
+  - `column` **(object)** - the column definition
+  - `columnIndex` **(number)** - the column index
 - `renderCell` **(function, optional)** - custom renderer for each cell. Receives one argument with the following fields:
-    + `value` **(object)** - the cell value
-    + `column` **(object)** - the column definition
-    + `columnIndex` **(number)** - the column index
-    + `row` **(object)** - the row definition
-    + `rowId` **(string)** - the row identifier
-
+  - `value` **(object)** - the cell value
+  - `column` **(object)** - the column definition
+  - `columnIndex` **(number)** - the column index
+  - `row` **(object)** - the row definition
+  - `rowId` **(string)** - the row identifier
 
 ## TreeTable
 
@@ -53,8 +55,8 @@ import {TreeTable} from '@streetscape.gl/monochrome';
 Inherits all `Table`'s props, and the following:
 
 - `rows` **(array)** - list of rows to render. Each row object must contain the following fields:
-    + `data` **(array)** - value for each column, e.g. `[val1, val2, ...]`
-    + `children` **(array)** - child rows
+  - `data` **(array)** - value for each column, e.g. `[val1, val2, ...]`
+  - `children` **(array)** - child rows
 - `indentSize` **(number, optional)** - Default `12`.
 
 ### Styling
@@ -78,13 +80,11 @@ The values define the styling overrides for the respective child components. Unl
 
 A custom style callback function will receive the following arguments:
 
-* `props` **(object)**
+- `props` **(object)**
   - `theme` **(object)** - the current theme
 
 The `row`, `cell` and `headerCell` callbacks will receive the following arguments:
 
-* `props` **(object)**
+- `props` **(object)**
   - `theme` **(object)** - the current theme
   - `index` **(number)** - the index of the current element
-
-


### PR DESCRIPTION
I've update usage examples in README such that they are valid JS and can be copied and pasted. 

For empty functions represented with `...`, I changed them to a noop function `() => {}`.
