### PR TITLE
Replace recomputeRowHeights() with forceUpdateGrid()

### DIFF
--- a/src/table/table.js
+++ b/src/table/table.js
@@ -85,7 +85,7 @@ export class Table extends PureComponent {
   _forceUpdate = () => {
     if (this._list) {
       this._cache.clearAll();
-      this._list.recomputeRowHeights();
+      this._list.forceUpdateGrid();
     }
   };
 


### PR DESCRIPTION
This change was made to address a scrolling issue when displaying treetable data where the number of rows remains the same, but the values within those rows change over time. The issue is that whenever you scroll down in the treetable, the scroll position resets to the top when new data comes in.

The change is based off of [this post](https://github.com/bvaughn/react-virtualized/issues/853#issuecomment-371084588) in a `react-virtualized` issue thread.